### PR TITLE
fix(docs): Improve documentation and add examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,30 +4,33 @@
 <!-- vim-markdown-toc GFM -->
 
 * [Program Flow](#program-flow)
-    * [Auto-Exposing Action Handlers](#auto-exposing-action-handlers)
-    * [Custom Action Signatures](#custom-action-signatures)
-    * [Required Task Format](#required-task-format)
+  * [State](#state)
+  * [Auto-Exposing Action Handlers](#auto-exposing-action-handlers)
+  * [Custom Action Signatures](#custom-action-signatures)
+  * [Required Task Format](#required-task-format)
 * [API](#api)
-  * [`set(<String>|<Object>, <Any>)`](#setstringobject-any)
-    * [Parmeters](#parmeters)
-  * [`lookup(<String>|<Object>|<Array>)`](#lookupstringobjectarray)
-    * [Parameters](#parameters)
-  * [`map(<Array>|<String>, <Function>, <String>)`](#maparraystring-function-string)
-    * [Parameters](#parameters-1)
-  * [`sort(<Array>|<String>, <Function>, <String>)`](#sortarraystring-function-string)
-    * [Parameters](#parameters-2)
-  * [`repeat(<Number>, <String>, <Object>, <String>)`](#repeatnumber-string-object-string)
-    * [Parameters](#parameters-3)
-  * [`execute()`](#execute)
-  * [`sleep(<Object>)`](#sleepobject)
-    * [Parameters](#parameters-4)
-  * [`reset()`](#reset)
+  * [constructor](#new-setupchainstate-actions)
+  * [set(label, value)](#setlabel-value)
+  * [map(collection, iterator, label)](#mapcollection-iterator-label)
+  * [sort(collection, comparator, label)](#sortcollection-comparator-label)
+  * [repeat(times, name, opts, label)](#repeattimes-name-opts-label)
+  * [sleep(opts)](#sleepopts)
+  * [reset()](#reset)
+  * [execute()](#execute)
+  * [lookup(input)](#lookupinput)
+* [Usage](#usage)
   * [Creating a chain](#creating-a-chain)
-  * [LAST](#last)
-    * [Interfaces](#interfaces)
-      * [`Node`](#node)
-      * [`Point`](#point)
-      * [`Position`](#position)
+  * [Actions](#actions)
+    * [Adding a New Action](#adding-a-new-action)
+  * [Helper Functions via Lookup](#helper-functions-via-lookup)
+    * [random(bytes)](#randombytes)
+    * [template(input)](#templateinput)
+    * [Exposing a New Helper Function](#exposing-a-new-helper-function)
+* [LAST](#last)
+  * [Interfaces](#interfaces)
+    * [`Node`](#node)
+    * [`Point`](#point)
+    * [`Position`](#position)
 
 <!-- vim-markdown-toc -->
 
@@ -48,6 +51,23 @@ in the order they are given.  Action functions are through builder functions (us
 placing a task onto a queue in the order specified, but they are not run until [.execute()](#execute) is called.  This
 requires a handler function added to the `SetupChain` for each action to expose it.  This can
 be done automatically (see below), or defined in the sub-class by the developer.
+
+### State
+The result returned from each action on the chain is stored in the state object. The label
+parameter of task signature will be used as the property for the return value in state.
+If omitted, the action name will be used instead (and if there are duplicate actions, the last one wins).
+
+```javascript
+const state = await chain
+  .foo('first') // Assumes `foo` and `bar` are an echo functions that returns the input
+  .foo('winner')
+  .foo('third', 'foo_two')
+  .bar({baz: 'foobarbaz'}, 'bar_label')
+  .bar('baz')
+  .execute()
+
+> {foo: 'winner', foo_two: 'third', bar_label: {baz: 'foobarbaz'}, bar: 'baz'}
+```
 
 ### Auto-Exposing Action Handlers
 
@@ -83,15 +103,32 @@ myCustomAction(firstParam, secondParam, label) {
 
 # API
 
-`new SetupChain([Object], [Object])`
+## `new SetupChain(state, actions)`
 
 Instantiates a new chain instance. If passed an object, it will be used as the initial
 internal state.  This is stored in `chain.state`, and is an object that holds the results
 of all the action calls.  As the second parameter, the object of action functions
 can be passed.
 
+**Parameters**
+
+* **state** [Object][] (_optional_): If passed, initializes the new chain with this state
+* **actions** [Object][] (_optional_): An object containing action names and their functions
+
 ```javascript
-const chain = new SetupChain({
+const SetupChain = require('@logdna/setup-chain')
+const my_actions = require('./my-action-functions.js')
+
+const first_chain = new SetupChain(null, my_actions)
+const first_state = await first_chain
+  .func1()
+  .func2()
+  .execute()
+
+> {func1: '...', func2: '...'}
+
+// Initialize with a pre-existing state object  
+const second_chain = new SetupChain({
   b: {
     c: 2
   , d: {
@@ -100,28 +137,26 @@ const chain = new SetupChain({
   }
 })
 
-await chain.execute()
-{
-  b: {
-    c: 2
-  , d: {
-      e: 3
-    }
-  }
-}
+const second_state = await second_chain.execute()
+
+> {b: {c: 2, d: {e: 3}}}
 ```
 
-## `set(<String>|<Object>, <Any>)`
-
-### Parmeters
-
-* **key** [String][]|[Object][]: The name of the key to set in the final output
-* **value** `Any`(_optional_): The value to be saved in `setupChain.state` and also returned
-  by `execute`. If the first parameter is an object, this parameter will be ignored.
-  Each of the key / value pairs will be used as function arguments
+## `set(label, value)`
 
 Manually sets a value that will be saved in the final output and persisted across
-executions.
+executions. This is a chain action resolved by [execute](#execute).
+
+**Parameters**
+
+* **label** [String][]|[Object][]: The name of the key to set in the final output. If
+  this value is an [Object][], then each of its values will be passed through `this.lookup`
+  for rendering.
+* **value** `Any`(_optional_): Value to be stored at `label` in `setupChain.state`. This
+  can also be a string in `lookup` form, beginning with a `#` or `!`. These will be passed
+  through `this.lookup` and stored at `label` in `setupChain.state`.
+
+**Returns:** `this<SetupChain>`
 
 ```javascript
 const chain = new SetupChain()
@@ -139,60 +174,81 @@ chain.set({
   foo: 1
 , 'a.b': '#foo'
 , bar: '!random'
+, combine: '!template:"foo-{{#foo}}, ab-{{#a.b}}"'
 })
 await chain.execute()
 
-> {foo: 1, bar: 'af4b31', a: {b: 1}}
+> {foo: 1, bar: 'af4b31', a: {b: 1}, combine: 'foo-1, ab-1'}
 ```
 
-## `lookup(<String>|<Object>|<Array>)`
+## `map(collection, iterator, label)`
 
-### Parameters
+Takes a collection (array, or `#lookup` value), and applies an iterator function to each item.
+The return value from the iterator will be the final result.  Results are returned in an array,
+and placed into the chain state at `label`. This is a chain action resolved by [execute](#execute).
 
-* **input** `Any`: The string path or object to lookup
+**Parameters**
 
-Resolves lookup value. This function is generally used by actions to resolve values
-from the chain as it is executes.
-
-* If the input is a string, and starts with a `#` symbol it is considered to be a lookup path and will
-  return the requested value from internal state if found.
-* If the input is a string, and starts with a `!` symbol it is considered a function call and will call
-  any registered actions from the chain instance and store the result in internal state.
-* If the input is an object, each key in the object will be resolved following the above rules
-* If the input is an array, each item in the array will be resolved following the above rules
-
-## `map(<Array>|<String>, <Function>, <String>)`
-
-### Parameters
-
-* **collection** [Array][]: An array/collection of data to apply the map function to.  A string can be
+* **collection** [Array][]|[String][]: An array/collection of data to apply the map function to.  A string can be
   given in order to use `lookup`, e.g. `'#myUsers'`
 * **iterator** [Function][]: This is the iterator function that will receive each collection item.  It can
   be an `async` or regular function that accepts `item`.  *Currently this does not support callbacks*
 * **label** [String][]: Optional label in which to store the result.
 
-Takes a collection (array, or `#lookup` value), and applies an iterator function to each item.
-The return value from the iterator will be the final result.  Results are stored in an array,
-keyed by `label`, and order is maintained.
+**Returns:** `this<SetupChain>`
 
-## `sort(<Array>|<String>, <Function>, <String>)`
+```javascript
+const chain = new SetupChain()
+const state = await chain
+  .set('my_array', [1, 2, 3])
+  .map('#my_array', async function addOneSecond(num) {
+    const result = await addOne(num)
+    return result
+  }, 'one_sec_Func')
+  .execute()
 
-### Parameters
+> {one_sec_Func: [2, 3, 4]}
+```
 
-* **collection** [Array][]: An array/collection of data to apply the sort function to.  A string can be
-  given in order to use `lookup`, e.g. `'#myCollection'`
-* **comparator** [Function][]: This is the the comparator function ultimately used by Javascript's
-  `Array.prototype.sort` function.  The input array *will not be mutated*.
-* **label** [String][]: Optional label in which to store the result.
+## `sort(collection, comparator, label)`
 
 Takes a collection (array, or `#lookup`) and applies a [sort function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
 to each item.  Although this uses Javascript's `sort` function under the hood (which mutates),
 calling `setupChain.sort` will NOT mutate the input.  This is done for consistency since
 the `lookup` result will sometimes provide a new array, and sometimes not.
+This is a chain action resolved by [execute](#execute).
 
-## `repeat(<Number>, <String>, <Object>, <String>)`
+**Parameters**
 
-### Parameters
+* **collection** [Array][]|[String][]: An array/collection of data to apply the sort function to.  A string can be
+  given in order to use `lookup`, e.g. `'#myCollection'`
+* **comparator** [Function][]: This is the the comparator function ultimately used by Javascript's
+  `Array.prototype.sort` function.  The input array *will not be mutated*.
+* **label** [String][]: Optional label in which to store the result.
+
+**Returns:** `this<SetupChain>`
+
+```javascript
+function comparator(a, b) {
+  if (a < b) return -1
+  if (a > b) return 1
+  return 0
+}
+const chain = new SetupChain()
+const state = await chain
+  .set('cols', ['biz', 'zarf', 'biz', 'clunk', 'goof', 'app'])
+  .sort(cols, comparator, 'cols_sorted')
+  .execute()
+
+> {cols_sorted: ['app', 'biz', 'biz', 'clunk', 'goof', 'zarf']}
+```
+
+## `repeat(times, name, opts, label)`
+
+Executes each task added sequentially and collects the results into a single object.
+This is a chain action resolved by [execute](#execute).
+
+**Parameters**
 
 * **times** [Number][]: The number of times to repeat the given action name
 * **name** [String][]: The name of the action to execute.  This **must** already exist
@@ -202,44 +258,117 @@ the `lookup` result will sometimes provide a new array, and sometimes not.
   supported.
 * **label** [String][]: Optional label in which to store the result.
 
-## `execute()`
-
-Executes each task added sequentially and collects the results into a single object.
-The results for `execute` are returned. The internal state will be Persisted.
-
-**returns**: [Object][]
+**Returns:** `this<SetupChain>`
 
 ```javascript
-await new SetupChain()
-  .foo()
-  .bar()
-  .insertDBRecord({}, 'record')
-  .execute()
+const SetupChain = require('@logdna/setup-chain')
 
-{
-  foo: 'bar'
-, bar: 'foo'
-, record: { id: 1 }
+class MyChain extends SetupChain {
+  constructor(state) {
+    super(state, {
+      hello: async () => {
+        return 'hi'
+      }
+    })
+  }
 }
+
+const chain = new MyChain()
+chain
+  .repeat(5, 'hello', {}, 'result')
+  .execute()
+  .then((result) => {
+    console.log(result)
+  })
+
+> {result: ['hi', 'hi', 'hi', 'hi', 'hi']}
 ```
 
-## `sleep(<Object>)`
+## `sleep(opts)`
 
-### Parameters
+When used in a chain, it will wait for a specified number of milliseconds before returning. Since this is a chain action, the sleep will appear to happen sequentially
+within the action chain.
+
+**Parameters**
 
 * **opts** [Object][]: configuration options
   * **ms** [Number][]: The number of milliseconds to wait before continuing
 
-This is a builder function for the `sleep` action.
-It will Waits for a specified number of milliseconds before returning.
-
-**returns**: SetupChain
+**Returns**: `this<SetupChain>`
 
 ## `reset()`
 
 Manually clears internal state and any pending tasks
 
-**returns**: SetupChain
+**Returns**: `this<SetupChain>`
+
+## `execute()`
+
+Resolves the promises returned by chain actions, and returns the result
+of each action in a single object. This should be the final
+method in any chain, otherwise the actions will not be resolved into values.
+After `execute` is called, the return value is also stored in `chain.state` for
+access later, even if the return value is not immediately used.
+
+**Returns**: [Object][]
+
+## `lookup(input)`
+
+This function is generally used by actions to resolve values
+from the chain as it is executes, thus this function **is not chainable**. For a chainable
+action that persists a value to the chain state, use [set()](#setstringobject-any) instead.
+
+**Parameters**
+
+* **input** [String][]|[Object][]|[Array][]: The string path or object to look up
+
+  * If the input is a string, and starts with a `#` symbol it is considered to be a lookup path and will
+  return the requested value from internal state if found.
+    * Array lookups should use the index value in dot notation, e.g. `#biz.1`
+  * If the input is a string, and starts with a `!` symbol it is considered a function call and will call
+    any registered actions from the chain instance and store the result in internal state.
+  * If the input is an object, each key in the object will be resolved following the above rules.
+  * If the input is an array, each item in the array will be resolved following the above rules.
+
+**Returns:** [String][]|[Object][]|[Array][]
+
+```javascript
+const chain = new SetupChain()
+const state = chain
+  .set('one', 1)
+  .set('two', 2)
+  .set('three.one', 1)
+  .set('four', ['a', 'b', 'c', {d: 'bleck'}])
+  .set('five', '#four.2') // Indirectly use `lookup` within a chain
+  .execute()
+
+chain.lookup('#one') // 1
+chain.lookup('#three') // {one: 1}
+chain.lookup('#three.one') // 1
+chain.lookup('#four.2') // 'c'
+chain.lookup('#four.3.d') // 'bleck'
+chain.lookup('!template:"{{#one}}{{#two}}{{#three.one}}"{{#four.0}}"') // '121a'
+
+state.five // 'c'
+```
+
+# Usage
+
+In your test suites you can instantiate a chain instance to perform a series of async tasks
+while storing the result in a single object. Actions can do anything from returning
+random data, inserting records into a data store, to sending log entries to a remote parser. Existing code from your project can be trivially wired up as actions on the chain. For example, if you had a `organization-create.js` and a `user-create.js`, they could be called like so:
+
+```javascript
+const state = await new MyChain()
+  .createOrganization()
+  .set('user_id', '!random:5')
+  .createUser({id: '#user_id'})
+  .execute()
+
+console.log(state)
+
+> {createOrganization: 'My Test Org!', createUser: '04335c3fcb'}
+```
 
 ## Creating a chain
 
@@ -261,14 +390,158 @@ class MyChain extends SetupChain {
 }
 ```
 
-## LAST
+## Actions
 
-![last](./asset/last.png)
+An action is simply an async function that performs some action and optionally returns
+some value. Every action function is called in the context of the `SetupChain` instance.
+
+### Adding a New Action
+
+```javascript
+const actions = {
+  name: async (opts) => {
+    return opts.name || randomName()
+  }
+
+  greet: async (opts) => {
+    const defaults = {
+      greeting: 'hello'
+    , names: []
+    }
+
+    const config = this.lookup({
+      ...defaults
+    , ...opts
+    })
+
+    return config.names.map((name) => {
+      return `${config.greeting} ${name}`
+    })
+  }
+}
+
+class MyChain extends SetupChain {
+  constructor(state) {
+    super(state, actions)
+  }
+}
+```
+
+The result of previous function calls in the chain can be passed as arguments into another.
+The values of previous results can be accessed using the `#` symbol followed by the name
+of the key. Simple Object path notation is supported
+
+```javascript
+const state = await new MyChain()
+  .name({name: 'greg'}, 'name_1')
+  .name({name: 'fred'}, 'name_2')
+  .greet({
+    greeting: 'Goodbye'
+  , names: ['#name_1', '#name_2']
+  }, 'greeting_1')
+  .execute()
+
+console.log(state)
+
+{
+  name_1: 'greg'
+  name_2: 'fred'
+, greeting_1: ['Goodbye greg', 'Goodbye fred']
+}
+
+```
+
+## Helper Functions via `lookup`
+
+The `lookup` function has the ability to execute functions when simple object path lookups aren't sufficient.
+The syntax for function execution is as follows. Simple arguments can be passed.
+If arguments are passed, numeric and boolean values will be casted to the
+appropriate type. Everything else will be handled as a string. String arguments
+must be quoted with either single or double quotes if the string contains a comma.
+Functions may also be used as arguments, but must use the more conventional call `()`
+syntax to ensure arguments are passed appropriately.
+
+```
+!<name>:arg,arg,arg
+!<name>:"one,two",three
+!<name>("one,two", !random:1, !foo("bar", "baz"), #nested.key)
+```
+
+### Included Helper Functions
+
+There is a few helper functions that we felt were valuable enough to include in
+the base class.
+
+### `random(bytes)`
+Generates a random HEX string. It accepts an optional single argument that specifies
+the number of random bytes to generate. This can be used when generating
+unique ids or names to be used in database records, for example. Combined with
+`!template`, this is a useful helper function.
+
+**Parameters**
+
+* **bytes** [Number][]: The number of bytes in the result
+
+**Returns:** [String][]
+
+```javascript
+chain.lookup('!random:2') // 3830
+chain.lookup('!random:10') // eddbdf576eac2ded313d
+```
+
+### `template(input)`
+Returns a string with replacement patterns from the chain. Templates are rendered in the
+same sequence as other operations on the chain. Only the data from actions prior to the
+template function will be available for replacement. `template` supports a basic bracket
+syntax for replacements where everything in between double curly bracews (`{{ }}`) is
+evaluated. This means that both `#` and `!` syntax is supported for deep
+[lookup](#lookupinput) calls.
+
+**Parameters**
+
+* **input** [String][]: The string template to parse
+
+**Returns:** [String][]
+
+```javascript
+await chain.set('name', 'World').execute()
+await chain.set('foo', {bar: "baz"}).execute()
+
+chain.lookup('!template:"Hello {{#name}}"') // Hello World
+chain.lookup('!template:"Hello {{#name}} - {{#foo.bar}}"') // Hello World - baz
+chain.lookup('!template:"Hello, my name is {{#name}}"') // Hello, my name is World
+```
+
+### Exposing a New Helper Function
+
+Any instance method that is prefixed with `$` is available as an executable function through [lookup](#lookupinput) by using a `!` in from of the lookup string. In
+these cases, the string will be [the parameters needed for the function](#helper-functions-via-lookup).
+
+```javascript
+class MyChain extends SetupChain {
+  constructor(state) {
+    super(state)
+  }
+
+  $max(...args) {
+    return Math.max(...this.lookup(args))
+  }
+}
+new MyChain({three: 3, val: 100})
+  .lookup('!max: 1,2,#three,#val') // 100
+```
+
+# LAST
 
 **L**ookup **A**bstract **S**yntax **T**ree
 
 `last` is a specification for representing the [lookup](#lookupstringobjectarray)
 input format as an abstract syntax tree. It implements the [unist][] spec.
+This is the parser/lexer used when inspecting inputs for the `lookup` command. This
+section is for documentation purposes only, and most likely will not be needed
+by users of this package.
+
+![last](./asset/last.png)
 
 ![syntax diagram](./asset/syntax.png)
 
@@ -399,137 +672,6 @@ Yields:
   , value: 'foo.bar'
   }]
 }
-```
-
-## Usage
-
-In your test suites you can use a chain instance to perform a series of async tasks
-while storing the result in a single object. Actions can do anything from returning
-random data, inserting records into a data store, to sending log entries to a remote parser.
-
-
-```javascript
-const state = await new MyChain().execute() // noop
-console.log(state)
-> {}
-```
-
-## Actions
-
-An action is simply an async function that performs some action and optionally returns
-some value. Every action function is called in the context of the Chain instance.
-
-### Adding a new action
-
-```javascript
-const actions = {
-  name: async (opts) => {
-    return opts.name || randomName()
-  }
-
-  greet: async (opts) => {
-    const defaults = {
-      greeting: 'hello'
-    , names: []
-    }
-
-    const config = this.lookup({
-      ...defaults
-    , ...opts
-    })
-
-    return config.names.map((name) => {
-      return `${config.greeting} ${name}`
-    })
-  }
-}
-
-class MyChain extends SetupChain {
-  constructor(state) {
-    super(state, actions)
-  }
-}
-```
-
-The result of previous function calls in the chain can be passed as arguments into another.
-The values of previous results can be accessed using the `#` symbol followed by the name
-of the key. Simple Object path notation is supported
-
-```javascript
-const state = await new MyChain()
-  .name({name: 'greg'}, 'name_1')
-  .name({name: 'fred'}, 'name_2')
-  .greet({
-    greeting: 'Goodbye'
-  , names: ['#name_1', '#name_2']
-  }, 'greeting_1')
-  .execute()
-
-console.log(state)
-
-{
-  name_1: 'greg'
-  name_2: 'fred'
-, greeting_1: ['Goodbye greg', 'Goodbye fred']
-}
-
-```
-
-## Functions
-
-The `lookup` function has the ability to execute functions when simple object path lookups aren't sufficient.
-The syntax for function execution is as follows. Simple arguments can be passed.
-If arguments are passed, numeric and boolean values will be casted to the
-appropriate type. Everything else will be handled as a string. String arguments
-must be quoted with either single or double quotes if the string contains a comma.
-Functions may also be used as arguments, but must use the more conventional call `()`
-syntax to ensure arguments are passed appropriately.
-
-```
-!<name>:arg,arg,arg
-!<name>:"one,two",three
-!<name>("one,two", !random:1, !foo("bar", "baz"), #nested.key)
-```
-
-### `random(<Number>)`
-Generates a random HEX string. It accepts an optional single argument that specifies
-the number of random bytes to generate.
-
-```javascript
-chain.lookup('!random:2') // 3830
-chain.lookup('!random:10') // eddbdf576eac2ded313d
-```
-
-### `template(<String>)`
-Returns a string with replacement patterns from the chain. Templates are rendered in the
-same sequence as other operations on the chain. Only the data from actions prior to the
-template function will be available for replacement.
-
-Templates supports a basic bracket syntax for replacements:
-
-```javascript
-chain.set('name', 'World')
-chain.set('foo', {bar: "baz"})
-chain.lookup('!template:"Hello {{#name}}"') // Hello World
-chain.lookup('!template:"Hello {{#name}} - {{#foo.bar}}"') // Hello World - baz
-chain.lookup('!template:"Hello, my name is {{#name}}"') // Hello, my name is World
-```
-
-### Exposing a new function
-
-Any instance method that is prefixed with `$` is available as an executable function through a `lookup`
-
-```javascript
-class MyChain extends SetupChain {
-  constructor(state) {
-    super(state)
-  }
-
-  $max(...args) {
-    return Math.max(...args)
-  }
-}
-new MyChain().lookup('!max:2,10,5,3') // 10
 ```
 
 [Object]: https://mdn.io/object

--- a/lib/chain.js
+++ b/lib/chain.js
@@ -25,7 +25,7 @@ module.exports = class SetupChain {
     this.lexer = new Lexer()
     this.visitor = new Visitor()
     this.state = state || {}
-    this.keep = {}
+    this.keep = {} // Used by `set` to merge with final results
     this.tasks = []
     this.actions = {
       ...builtins

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     ]
   },
   "dependencies": {
-    "@logdna/stdlib": "^1.0.1",
+    "@logdna/stdlib": "^1.0.2",
     "chevrotain": "^9.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "casual": "^1.6.2",
     "eslint": "^7.25.0",
     "eslint-config-logdna": "^5.0.0",
-    "moment": "^2.27.0",
+    "moment": "^2.29.1",
     "semantic-release": "^17.4.2",
     "semantic-release-config-logdna": "^1.3.0",
     "tap": "^15.0.6",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,6 @@
   },
   "dependencies": {
     "@logdna/stdlib": "^1.0.1",
-    "chevrotain": "^7.0.3"
+    "chevrotain": "^9.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "moment": "^2.29.1",
     "semantic-release": "^17.4.2",
     "semantic-release-config-logdna": "^1.3.0",
-    "tap": "^15.0.6",
+    "tap": "^15.0.9",
     "tap-parser": "^10.1.0",
     "tap-xunit": "^2.4.1"
   },

--- a/test/unit/chain.js
+++ b/test/unit/chain.js
@@ -24,6 +24,16 @@ test('chain', async (t) => {
     t.equal(chain.lookup(null), null, 'no input returns null')
     t.equal(chain.lookup('a'), 'a', 'returns literal values')
     t.equal(chain.lookup('*'), '*', 'returns literal values')
+    t.same( // same will ignore that the `found` has a null prototype, but expected doesn't
+      chain.lookup({one: 1, two: 2})
+    , {one: 1, two: 2}
+    , 'Returns object literals with no substitutions'
+    )
+    t.same(
+      chain.lookup([5, 'something', {one: 1}])
+    , [5, 'something', {one: 1}]
+    , 'Returns array literals with no substitutions, but mixed types'
+    )
     t.equal(chain.lookup(
       '2020-11-21T19:16:27.705Z')
     , '2020-11-21T19:16:27.705Z'
@@ -152,6 +162,7 @@ test('chain', async (t) => {
           one: '!random'
         , two: ['#foo', '#one']
         })
+        .set('message', '!template:"{{#foo}} added first, then in an array [{{#two.0}}]"')
         .execute()
 
       t.match(state, {
@@ -159,6 +170,7 @@ test('chain', async (t) => {
       , two: ['bar', state.one]
       , foo: 'bar'
       , set: undefined
+      , message: 'bar added first, then in an array [bar]'
       }, 'can resolve array values')
     }
   })


### PR DESCRIPTION
**fix(docs): Improve documentation and add examples**

The documentation needs some tweaks to be more fluid.
Functions like `lookup` need better descriptions since
it cannot be used in a chain.  Add tests and examples
to improve this, and make the documentation more consistent.

---

**chore(deps): @logdna/stdlib@1.0.2**


---

**chore(deps): tap@15.0.9**


---

**chore(deps): chevrotain@9.0.1**


---

**chore(deps): moment@2.29.1**
