### PR TITLE
feat(chain): add support for luxon object during lookups

### DIFF
--- a/lib/chain.js
+++ b/lib/chain.js
@@ -17,6 +17,9 @@ const COMPLEX_LOOKUP_TYPES = new Set([
 , 'moment'
 , 'boolean'
 , 'number'
+, 'luxondatetime'
+, 'luxoninterval'
+, 'luxonduration'
 ])
 
 module.exports = class SetupChain {

--- a/lib/lang/type-of.js
+++ b/lib/lang/type-of.js
@@ -11,6 +11,9 @@ module.exports = function typeOf(value) {
   if (value === null) return 'null'
   if (value === undefined) return 'undefined'
   if (value._isAMomentObject && typeof value.format === 'function') return 'moment'
+  if (value.isLuxonDateTime) return 'luxondatetime'
+  if (value.isLuxonInterval) return 'luxoninterval'
+  if (value.isLuxonDuration) return 'luxonduration'
   const parts = TYPE_EXP.exec(toString.call(value))
   return parts[1].toLowerCase()
 }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "casual": "^1.6.2",
     "eslint": "^8.21.0",
     "eslint-config-logdna": "^6.1.0",
+    "luxon": "^3.2.1",
     "moment": "^2.29.1",
     "semantic-release": "^17.4.4",
     "semantic-release-config-logdna": "^1.3.0",

--- a/test/unit/lang/typeof.js
+++ b/test/unit/lang/typeof.js
@@ -2,6 +2,7 @@
 
 const {test, threw} = require('tap')
 const Moment = require('moment')
+const luxon = require('luxon')
 const typeOf = require('../../../lib/lang/type-of.js')
 
 class FooBar {
@@ -64,8 +65,25 @@ test('typeOf', (t) => {
   , {
       value: Moment()
     , expected: 'moment'
+    , message: 'typeOf(Moment()) === moment'
+    }
+  , {
+      value: luxon.DateTime.now()
+    , expected: 'luxondatetime'
+    , message: 'typeOf(luxon.DateTime.now()) === luxondatetime'
+    }
+  , {
+      value: luxon.Duration.fromMillis(Date.now())
+    , expected: 'luxonduration'
+    , message: 'typeOf(new luxon.Duration()) == luxonduration'
+    }
+  , {
+      value: new luxon.Interval({start: luxon.DateTime.now()})
+    , expected: 'luxoninterval'
+    , message: 'typeOf(new luxon.Interval()) === luxoninterval'
     }
   ]
+
   for (const current of cases) {
     t.equal(
       typeOf(current.value)


### PR DESCRIPTION
With the deprecation of moment, luxon is sane replacement in testing. In a similar fashion as with moment, we don't want to break the prototype chain when passing luxon objects around. Unlike moment, there are several date-ish object we need to account for. This will allow users to reference and manipulate luxon object during chain execution with out having to cast between native date objects