### PR TITLE
fix(lookup): don't parse nested array elements as string templates

### DIFF
--- a/lib/chain.js
+++ b/lib/chain.js
@@ -100,9 +100,7 @@ module.exports = class SetupChain {
       // remap array values with lookup result
       if (Array.isArray(value)) {
         out[key] = value.map((val) => {
-          if (typeOf(val) === 'object') return this.lookup(val)
-          const resolved = this[lookup](this.parse(val))
-          return resolved
+          return this.lookup(val)
         })
         continue
       }

--- a/test/unit/chain.js
+++ b/test/unit/chain.js
@@ -102,6 +102,12 @@ test('chain', async (t) => {
     }
 
     {
+      const expected = {position: [11, 2]}
+      const lookup = {position: [11, 2]}
+      t.same(chain.lookup(lookup), expected, 'array values parse number literals')
+    }
+
+    {
       const expected = {key: 11, values: [2, 10, {foo: 3}]}
       const lookup = {key: '#g', values: ['#b.c', '#f', {foo: '#b.d.e'}]}
       t.same(chain.lookup(lookup), expected, 'can populate nested object/array')


### PR DESCRIPTION
When parsing nested arrays in the lookup function, pass all values through the lookup parser instead of just object types and handling the rest as if they are string templates.