### PR TITLE
fix: throw error when calling an undefined chain function

### DIFF
--- a/lib/chain.js
+++ b/lib/chain.js
@@ -216,7 +216,9 @@ module.exports = class SetupChain {
 
   [call](fn, args) {
     const fnkey = `$${fn}`
-    if (typeof this[fnkey] !== 'function') return
+    if (typeof this[fnkey] !== 'function') {
+      throw new TypeError(`'${fn}' is not a callable chain function`)
+    }
 
     const mapper = this[astToValue].bind(this)
     const resolved = args.map(mapper)

--- a/test/integration/chain.js
+++ b/test/integration/chain.js
@@ -242,6 +242,13 @@ test('Setup chain', async (t) => {
     }
   })
 
+  t.test('calling undefined chain function', async (t) => {
+    const chain = new Chain()
+    chain.set('foo', {bar: '!baz("qux")'})
+
+    t.rejects(chain.execute(), 'baz action is undefined')
+  })
+
   t.test('Default SetupChain (no actions, state); Only built-ins', async (t) => {
     const chain = new Chain(null, null)
     t.same(chain.state, {}, 'Empty state')

--- a/test/unit/chain.js
+++ b/test/unit/chain.js
@@ -84,9 +84,11 @@ test('chain', async (t) => {
     }
 
     {
-      const expected = [null]
       const lookup = ['!notfound']
-      t.same(chain.lookup(lookup), expected, 'invalid key lookup returns null')
+      t.throws(() => { chain.lookup(lookup) }, {
+        name: 'TypeError'
+      , message: '\'notfound\' is not a callable chain function'
+      }, 'invalid function lookup throws')
     }
 
     {


### PR DESCRIPTION
Previously when calling an undefined function, `execute` would silently fail.

BREAKING CHANGE: Invalid function calls/lookups will now throw an error.

Closes #133